### PR TITLE
Fix typo in IUnityGraphicsVulkan.h

### DIFF
--- a/PluginSource/source/Unity/IUnityGraphicsVulkan.h
+++ b/PluginSource/source/Unity/IUnityGraphicsVulkan.h
@@ -100,7 +100,7 @@ enum UnityVulkanEventRenderPassPreCondition
     kUnityVulkanRenderPass_EnsureInside,
 
     // Make sure that there is currently no RenderPass in progress.
-	// This allows e.g. resource uploads.
+    // This allows e.g. resource uploads.
     // Ends the current render pass (and resumes it afterwards if needed)
     // If used in combination with the SRP RenderPass API the resuls is undefined.
     kUnityVulkanRenderPass_EnsureOutside

--- a/PluginSource/source/Unity/IUnityGraphicsVulkan.h
+++ b/PluginSource/source/Unity/IUnityGraphicsVulkan.h
@@ -93,14 +93,14 @@ enum UnityVulkanEventRenderPassPreCondition
     // This is the default precondition
     kUnityVulkanRenderPass_DontCare,
 
-    // Make sure that there is currently no RenderPass in progress.
-    // This allows e.g. resource uploads.
+    // Make sure that there is currently RenderPass in progress.
     // There are no guarantees about the currently bound descriptor sets, vertex buffers, index buffers and pipeline objects
     // Unity does however set dynamic pipeline set VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR based on the current settings
     // If used in combination with the SRP RenderPass API the resuls is undefined
     kUnityVulkanRenderPass_EnsureInside,
 
     // Make sure that there is currently no RenderPass in progress.
+	// This allows e.g. resource uploads.
     // Ends the current render pass (and resumes it afterwards if needed)
     // If used in combination with the SRP RenderPass API the resuls is undefined.
     kUnityVulkanRenderPass_EnsureOutside


### PR DESCRIPTION
Fix typo in IUnityGraphicsVulkan.h/UnityVulkanEventRenderPassPreCondition which has caused some confusion.