### PR TITLE
Return vkGetInstanceProcAddr from Hook_vkGetInstanceProcAddr for use by other plugins

### DIFF
--- a/PluginSource/source/RenderAPI_Vulkan.cpp
+++ b/PluginSource/source/RenderAPI_Vulkan.cpp
@@ -121,7 +121,7 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL Hook_vkGetInstanceProcAddr(VkIns
     INTERCEPT(vkCreateInstance);
 #undef INTERCEPT
 
-    return NULL;
+    return vkGetInstanceProcAddr(device, funcName);
 }
 
 static PFN_vkGetInstanceProcAddr UNITY_INTERFACE_API InterceptVulkanInitialization(PFN_vkGetInstanceProcAddr getInstanceProcAddr, void*)


### PR DESCRIPTION
Currently our example code returns NULL, which would prevent other plugins from initialising.

This PR updates the code to be compatible with the V2 API use case.