### PR TITLE
Return when vertex layout unexpected

### DIFF
--- a/PluginSource/source/RenderingPlugin.cpp
+++ b/PluginSource/source/RenderingPlugin.cpp
@@ -262,6 +262,13 @@ static void ModifyVertexBuffer()
 		return;
 	int vertexStride = int(bufferSize / vertexCount);
 
+	// Unity should return us a buffer that is the size of `vertexCount * sizeof(MeshVertex)`
+	// If that's not the case then we should quit to avoid unexpected results.
+	// This can happen if https://docs.unity3d.com/ScriptReference/Mesh.GetNativeVertexBufferPtr.html returns
+	// a pointer to a buffer with an unexpected layout.
+	if (static_cast<unsigned int>(vertexStride) != sizeof(MeshVertex))
+		return;
+
 	const float t = g_Time * 3.0f;
 
 	char* bufferPtr = (char*)bufferDataPtr;

--- a/UnityProject/Assets/UseRenderingPlugin.cs
+++ b/UnityProject/Assets/UseRenderingPlugin.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using System;
 using System.Collections;
 using System.Runtime.InteropServices;
-
+using UnityEngine.Rendering;
 
 public class UseRenderingPlugin : MonoBehaviour
 {
@@ -81,6 +81,19 @@ public class UseRenderingPlugin : MonoBehaviour
 	{
 		var filter = GetComponent<MeshFilter> ();
 		var mesh = filter.mesh;
+
+		// This is equivalent to MeshVertex in RenderingPlugin.cpp
+		var desiredVertexLayout = new[]
+		{
+			new VertexAttributeDescriptor(VertexAttribute.Position, VertexAttributeFormat.Float32, 3),
+			new VertexAttributeDescriptor(VertexAttribute.Normal, VertexAttributeFormat.Float32, 3),
+			new VertexAttributeDescriptor(VertexAttribute.Color, VertexAttributeFormat.Float32, 4),
+			new VertexAttributeDescriptor(VertexAttribute.TexCoord0, VertexAttributeFormat.Float32, 2)
+		};
+
+		// Let's be certain we'll get the vertex buffer layout we want in native code
+		mesh.SetVertexBufferParams(mesh.vertexCount, desiredVertexLayout);
+
 		// The plugin will want to modify the vertex buffer -- on many platforms
 		// for that to work we have to mark mesh as "dynamic" (which makes the buffers CPU writable --
 		// by default they are immutable and only GPU-readable).

--- a/UnityProject/Assets/UseRenderingPlugin.cs
+++ b/UnityProject/Assets/UseRenderingPlugin.cs
@@ -99,12 +99,6 @@ public class UseRenderingPlugin : MonoBehaviour
 		// by default they are immutable and only GPU-readable).
 		mesh.MarkDynamic ();
 
-		// Make sure to have vertex colors so that the plugin can rely on a known
-		// vertex layout (position+normal+color+UV). Since Unity 2019.3 it's easier
-		// since there are APIs to query all that info.
-		var colors = mesh.colors;
-		mesh.colors = colors;
-
 		// However, mesh being dynamic also means that the CPU on most platforms can not
 		// read from the vertex buffer. Our plugin also wants original mesh data,
 		// so let's pass it as pointers to regular C# arrays.


### PR DESCRIPTION
Since Unity no longer supports 2018.x or 2019.x I updated the script to manually define the vertex layout to set a slightly better and more readable example to prevent weird bugs.