### PR TITLE
Windows - Fix crash on startup, caused by glGetError

### DIFF
--- a/PluginSource/source/RenderAPI_OpenGLCoreES.cpp
+++ b/PluginSource/source/RenderAPI_OpenGLCoreES.cpp
@@ -138,7 +138,8 @@ static GLuint CreateShader(GLenum type, const char* sourceText)
 void RenderAPI_OpenGLCoreES::CreateResources()
 {
 #	if UNITY_WIN && SUPPORT_OPENGL_CORE
-	gl3wInit();
+	if (m_APIType == kUnityGfxRendererOpenGLCore)
+		gl3wInit();
 #	endif
 	// Make sure that there are no GL error flags set before creating resources
 	while (glGetError() != GL_NO_ERROR) {}

--- a/PluginSource/source/RenderAPI_OpenGLCoreES.cpp
+++ b/PluginSource/source/RenderAPI_OpenGLCoreES.cpp
@@ -137,6 +137,9 @@ static GLuint CreateShader(GLenum type, const char* sourceText)
 
 void RenderAPI_OpenGLCoreES::CreateResources()
 {
+#	if UNITY_WIN && SUPPORT_OPENGL_CORE
+	gl3wInit();
+#	endif
 	// Make sure that there are no GL error flags set before creating resources
 	while (glGetError() != GL_NO_ERROR) {}
 
@@ -154,10 +157,6 @@ void RenderAPI_OpenGLCoreES::CreateResources()
 #	if SUPPORT_OPENGL_CORE
 	else if (m_APIType == kUnityGfxRendererOpenGLCore)
 	{
-#		if UNITY_WIN
-		gl3wInit();
-#		endif
-
 		m_VertexShader = CreateShader(GL_VERTEX_SHADER, kGlesVProgTextGLCore);
 		m_FragmentShader = CreateShader(GL_FRAGMENT_SHADER, kGlesFShaderTextGLCore);
 	}


### PR DESCRIPTION
Recent PR cleared error flags before initialization which crashes Windows projects. On Linux this works fine as OpenGL is already initialized when program starts. On Windows you need to initialize OpenGL with gl3w, before calling any OpenGL function. That's why when we use `glGetError()`, program crashes as function points to nullptr.

To fix this, we initialize OpenGL before `glGetError` call.