### PR TITLE
WIP: Fix incorrect calculations of row pitch in d3d12 implementation

### DIFF
--- a/PluginSource/source/RenderAPI_D3D12.cpp
+++ b/PluginSource/source/RenderAPI_D3D12.cpp
@@ -1368,7 +1368,7 @@ void* RenderAPI_D3D12::BeginModifyTexture(void* textureHandle, int textureWidth,
 
     // Fill data
     // Clamp to minimum rowPitch of RGBA32
-    *outRowPitch = static_cast<int>(max(align_pow2(textureWidth * 4), 256));
+    *outRowPitch = (textureWidth * 4 + D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1) & ~(D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1);
     const UINT64 kDataSize = get_aligned_size(textureWidth, textureHeight, 4, *outRowPitch);
     if (!get_upload_resource(&s_upload_texture, kDataSize, D3D12_UPLOAD_HEAP_TEXTURE_BUFFER_NAME))
         return NULL;


### PR DESCRIPTION
With a 160x144 texture, the pitch would be aligned to be 1024 pixels wide, not 768 as D3D12 calculates it to be. This was causing issues on our end, where we would be drawing pixels with offsets that would accumulate over each row of pixels.

The width does not need to be a power of 2 - it turns out it just needs to be a multiple of 256, which is what `D3D12_TEXTURE_DATA_PITCH_ALIGNMENT` is defined to be.